### PR TITLE
odometry workaround

### DIFF
--- a/cob_sick_s300/ros/src/cob_scan_filter.cpp
+++ b/cob_sick_s300/ros/src/cob_scan_filter.cpp
@@ -121,7 +121,7 @@ public:
 			}
 			
 			for(int u = stop_scan; u<start_scan; u++) {
-				laser_scan.ranges.at(u) = laser_scan.range_min;
+				laser_scan.ranges.at(u) = 0.0; //laser_scan.range_min;
 			}
 			
 			if( it->at(1) >= laser_scan.angle_max ) stop_scan = num_scans-1;
@@ -132,7 +132,7 @@ public:
 		}
 		
 		for(unsigned int u = stop_scan; u<laser_scan.ranges.size(); u++) {
-			laser_scan.ranges.at(u) = laser_scan.range_min; //0.0
+			laser_scan.ranges.at(u) = 0.0; //laser_scan.range_min;
 		}
 		
 		// publish message

--- a/cob_sick_s300/ros/src/cob_sick_s300.cpp
+++ b/cob_sick_s300/ros/src/cob_sick_s300.cpp
@@ -189,8 +189,8 @@ class NodeClass
 			// fill message
 			laserScan.header.frame_id = frame_id;
 			laserScan.angle_increment = vdAngRAD[start_scan + 1] - vdAngRAD[start_scan];
-			laserScan.range_min = 0.0;
-			laserScan.range_max = 100.0;
+			laserScan.range_min = 0.001;
+			laserScan.range_max = 30.0;
 			laserScan.time_increment = (scan_duration) / (vdDistM.size());
 
 			// rescale scan


### PR DESCRIPTION
Änderungen bezüglich der ungenauen Odometrie:

cob_undercarriage_ctrl:
- Geänderte Ablaufsteuerung (Timer-Callback statt ros::Rate)
- Dadurch Aktualisierung der Odometrie sofort nach Eintreffen der Joint-States möglich

cob_base:
- Ini-Files für cob3-sim erzeugt, die conzentrische Lage der simulierten Räder berücksichtigen! (sim.launch in cob_base wählt das entsprechende File aus.
